### PR TITLE
Bugzilla 1743 - Align CoapCloudConf schemas with the latest CR

### DIFF
--- a/coapcloudconf.raml
+++ b/coapcloudconf.raml
@@ -32,8 +32,7 @@ traits:
 
 /example/CoAPCloudConfResURI?if=oic.if.baseline:
   description: |
-    CoAPCloudConf resource exposes configuration information for connecting to a
-    cloud server.
+    The CoAPCloudConf Resource exposes configuration information for connecting to an OCF Cloud.
   displayName: CoAP Cloud Configuration Resource Baseline Interface
   is: [ interface-baseline ] # valid for baseline method.
 
@@ -48,8 +47,8 @@ traits:
               {
                 "rt": ["oic.r.coapcloudconf"],
                 "at": "0f3d9f7fe5491d54077d",
-                "apn": "Authentication server",
-                "cis": "https://CloudServerURI",
+                "apn": "github",
+                "cis": "coaps+tcp://example.com:443",
                 "clec": 0
               }
   post:
@@ -61,8 +60,8 @@ traits:
         example: |
           {
             "at": "0f3d9f7fe5491d54077d",
-            "apn": "Authentication server",
-            "cis": "https://CloudServerURI"
+            "apn": "github",
+            "cis": "coaps+tcp://example.com:443"
           }
     responses:
       200:
@@ -72,25 +71,19 @@ traits:
             example: |
               {
                 "at": "0f3d9f7fe5491d54077d",
-                "apn": "Authentication server",
-                "cis": "https://CloudServerURI",
+                "apn": "github",
+                "cis": "coaps+tcp://example.com:443",
                 "clec": 0
               }
 /example/CoAPCloudConfResURI?if=oic.if.rw:
   description: |
-    CoAPCloudConf resource exposes configuration information for connecting to a
-    cloud server.
+    The CoAPCloudConf Resource exposes configuration information for connecting to an OCF Cloud.
   displayName: CoAP Cloud Configuration Resource Read Write Interface
   is: [ interface-rw ] # valid for RW method.
 
   get:
     description: |
-      Retrieve all essential information used for cloud registration that can
-      be updated by a client.
-      1. Access Token
-      2. Authentication provider name
-      3. Cloud interface server URL
-      4. Additonal configuration properties supported by device
+      Retrieve properties of CoAPCloudConf resource.
     responses:
       200:
         body:
@@ -100,8 +93,8 @@ traits:
               {
                 "rt": ["oic.r.coapcloudconf"],
                 "at": "0f3d9f7fe5491d54077d",
-                "apn": "Authentication server",
-                "cis": "https://CloudServerURI"
+                "apn": "github",
+                "cis": "coaps+tcp://example.com:443"
               }
   post:
     description: |
@@ -112,8 +105,8 @@ traits:
         example: |
           {
             "at": "0f3d9f7fe5491d54077d",
-            "apn": "Authentication server",
-            "cis": "https://CloudServerURI"
+            "apn": "github",
+            "cis": "coaps+tcp://example.com:443"
           }
     responses:
       200:
@@ -123,6 +116,6 @@ traits:
             example: |
               {
                 "at": "0f3d9f7fe5491d54077d",
-                "apn": "Authentication server",
-                "cis": "https://CloudServerURI",
+                "apn": "github",
+                "cis": "coaps+tcp://example.com:443"
               }

--- a/schemas/oic.r.coapcloudconf-schema.json
+++ b/schemas/oic.r.coapcloudconf-schema.json
@@ -8,31 +8,26 @@
       "properties": {
         "apn": {
           "type": "string",
-          "description": "Authentication provider's name issuing the auth code",
+          "description": "The Authorisation Provider through which an Access Token was obtained.",
           "pattern": "^.*$"
         },
         "cis": {
           "type": "string",
-          "description": "Indicates URL for CoAP native cloud interface server to be registered",
+          "description": "URL of OCF Cloud",
           "format": "uri"
         },
         "at": {
           "type": "string",
-          "description": "Indicates access token which is given in return of auth code issued by an appropriate account server",
-          "pattern": "^.*$"
-        },
-        "sid": {
-          "type": "string",
-          "description": "The Server identity of the OCF Cloud used for verifying the OCF Cloud certificate.",
+          "description": "Access Token which is returned by an Authorisation Provider or OCF Cloud.",
           "pattern": "^.*$"
         },
         "clec": {
-          "enum": [0, 1, 2, 3, 4, 5, 6, 7, 255],
-          "description": "Indicates a failure reason (0: No Error. 1: Failed to access CoAP Cloud server,  2: No response from CoAP Cloud server,  3: Invalid Access Token, 4: Failed to refresh Access Token, 5: Failed to find a registered device in CoAP Cloud, 6: Failed to find a registered user in CoAP Cloud, 7~254: Reserved, 255: Unknown error)",
+          "enum": [0, 1, 2, 3, 255],
+          "description": "Last Error Code during Cloud Provisioning (0: No Error, 1: Failed to access OCF Cloud server, 2: No response from OCF Cloud server, 3: Failed to refresh Access Token, 4~254: Reserved, 255: Unknown error)",
           "readOnly": true
         }
       },
-      "required":["cis"]
+      "required":["cis", "at"]
     }
   },
   "type": "object",

--- a/schemas/oic.r.coapcloudconf-schema.json
+++ b/schemas/oic.r.coapcloudconf-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.coapcloudconf-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core-extensions/schemas/oic.r.coapcloudconf-schema.json#",
   "definitions": {
     "oic.r.coapcloudconf": {
       "type": "object",
@@ -37,7 +37,7 @@
   },
   "type": "object",
   "allOf": [
-    { "$ref": "oic.core-schema.json#/definitions/oic.core"},
+    { "$ref": "../../core/schemas/oic.core-schema.json#/definitions/oic.core"},
     { "$ref": "#/definitions/oic.r.coapcloudconf" }
   ]
 }

--- a/schemas/oic.r.coapcloudconf-update-schema.json
+++ b/schemas/oic.r.coapcloudconf-update-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.coapcloudconf-update-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core-extensions/schemas/oic.r.coapcloudconf-update-schema.json#",
   "definitions": {
     "oic.r.coapcloudconf": {
       "type": "object",
@@ -32,7 +32,7 @@
   },
   "type": "object",
   "allOf": [
-    { "$ref": "oic.core-schema.json#/definitions/oic.core"},
+    { "$ref": "../../core/schemas/oic.core-schema.json#/definitions/oic.core"},
     { "$ref": "#/definitions/oic.r.coapcloudconf" }
   ]
 }

--- a/schemas/oic.r.coapcloudconf-update-schema.json
+++ b/schemas/oic.r.coapcloudconf-update-schema.json
@@ -8,26 +8,21 @@
       "properties": {
         "apn": {
           "type": "string",
-          "description": "Authentication provider's name issuing the auth code",
+          "description": "The Authorisation Provider through which an Access Token was obtained.",
           "pattern": "^.*$"
         },
         "cis": {
           "type": "string",
-          "description": "Indicates URL for CoAP native cloud interface server to be registered",
+          "description": "URL of OCF Cloud",
           "format": "uri"
         },
         "at": {
           "type": "string",
-          "description": "Indicates access token which is given in return of auth code issued by an appropriate account server",
-          "pattern": "^.*$"
-        },
-          "sid": {
-          "type": "string",
-          "description": "The Server identity of the OCF Cloud used for verifying the OCF Cloud certificate.",
+          "description": "Access Token which is returned by an Authorisation Provider or OCF Cloud.",
           "pattern": "^.*$"
         }
       },
-      "required":["cis"]
+      "required":["cis", "at"]
     }
   },
   "type": "object",


### PR DESCRIPTION
Update descriptions of properties. 
Add "at" to required properties.  
Remove "sid" property. 
Update examples.
Update CoapCloudConf schema paths relative to core extensions
