### PR TITLE
Bug 3120 - Optional WiFiConf Security properties

### DIFF
--- a/swagger2.0/oic.r.wificonf.swagger.json
+++ b/swagger2.0/oic.r.wificonf.swagger.json
@@ -276,7 +276,7 @@
         }
       },
       "type" : "object",
-      "required":["swmt", "swf", "swat", "swet", "tnn", "wat", "wet"]
+      "required":["swmt", "swf", "tnn"]
     },
     "WiFiConfUpdate" : {
       "properties": {
@@ -312,7 +312,7 @@
         }
       },
       "type" : "object",
-      "required":["tnn", "wat", "wet"]
+      "required":["tnn"]
     }
   }
 }


### PR DESCRIPTION
Make Wi-Fi Security Type properties (i.e., wat, wet, swat and swet) of WiFiConf Resource Type optional