### PR TITLE
Added missing query params

### DIFF
--- a/swagger2.0/oic.r.pushconfiguration.swagger.json
+++ b/swagger2.0/oic.r.pushconfiguration.swagger.json
@@ -20,7 +20,7 @@
     "application/json"
   ],
   "paths": {
-    "/PushConfigurationResURI" : {
+    "/PushConfigurationResURI?if=oic.if.ll" : {
       "get": {
         "description": "Collection of oic.r.notificationselector with associated push proxies.\nAllows a Server to be configured with one or more Push Notification destinations.\n",
         "parameters": [

--- a/swagger2.0/oic.r.pushreceiver.swagger.json
+++ b/swagger2.0/oic.r.pushreceiver.swagger.json
@@ -14,7 +14,7 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {
-    "/PushReceiverResURI": {
+    "/PushReceiverResURI?if=oic.if.rw": {
       "get": {
         "description": "Resource that defines the receiver for Push Notifications",
         "parameters": [


### PR DESCRIPTION
Swagger parser in CTT expects that all paths in a swagger either do not have a query that begins with `if=`, or that all paths do have a query that begins with `if=`. All existing OCF swaggers follow that rule except for two two new swaggers for Push Notification, which include one path with and one without `if=` query. This PR adds missing queries in swagger paths.